### PR TITLE
Keep things simple without using layoutName

### DIFF
--- a/addon/components/as-calendar/occurrence.js
+++ b/addon/components/as-calendar/occurrence.js
@@ -4,7 +4,6 @@ import computedDuration from 'ember-calendar/macros/computed-duration';
 export default Ember.Component.extend({
   attributeBindings: ['_style:style'],
   classNameBindings: [':as-calendar-occurrence'],
-  layoutName: 'components/as-calendar/occurrence',
   tagName: 'article',
 
   model: null,

--- a/addon/components/as-calendar/timetable/occurrence.js
+++ b/addon/components/as-calendar/timetable/occurrence.js
@@ -13,7 +13,6 @@ export default OccurrenceComponent.extend({
   isRemovable: true,
   dayWidth: Ember.computed.oneWay('timetable.dayWidth'),
   referenceElement: Ember.computed.oneWay('timetable.referenceElement'),
-  occurrenceTemplateName: 'components/as-calendar/timetable/occurrence',
 
   _calendar: Ember.computed.oneWay('model.calendar'),
   _dayEndingTime: Ember.computed.oneWay('day.endingTime'),

--- a/app/templates/components/as-calendar/occurrence.hbs
+++ b/app/templates/components/as-calendar/occurrence.hbs
@@ -4,8 +4,4 @@
   {{else}}
     <h1 style={{titleStyle}}>{{title}}</h1>
   {{/if}}
-
-  {{#if occurrenceTemplateName}}
-    {{partial occurrenceTemplateName}}
-  {{/if}}
 </div>

--- a/app/templates/components/as-calendar/timetable/occurrence.hbs
+++ b/app/templates/components/as-calendar/timetable/occurrence.hbs
@@ -1,9 +1,17 @@
-{{#unless isInteracting}}
-  {{#if isRemovable}}
-    <a {{action "remove" bubbles=false}} class="remove"></a>
+<div>
+  {{#if hasBlock}}
+    {{yield}}
+  {{else}}
+    <h1 style={{titleStyle}}>{{title}}</h1>
   {{/if}}
 
-  {{#if isResizable}}
-    <div class="resize-handle"></div>
-  {{/if}}
-{{/unless}}
+  {{#unless isInteracting}}
+    {{#if isRemovable}}
+      <a {{action "remove" bubbles=false}} class="remove"></a>
+    {{/if}}
+
+    {{#if isResizable}}
+      <div class="resize-handle"></div>
+    {{/if}}
+  {{/unless}}
+</div>


### PR DESCRIPTION
After updating to Ember 2.1 the layoutName setting doesn't seem to work anymore, so I've just opted to simplify things by removing it altogether and just using another template.