### PR TITLE
Fix font awesome dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,28 @@ We do not add any vendor CSS to your app by default, but you can include it if y
 @import 'addons/ember-calendar/main';
 ```
 
+## Build Options
+
+Font Aweseome assets are exported during a build by default which may conflict
+with assets already being exported by your project. To prevent this, add
+the following option to your ember-cli-build.js file:
+
+```js
+// ember-cli-build.js
+
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
+    
+    // Add options here
+    emberCalendar: {
+      includeFontAwesomeAssets: false
+    }
+  });
+
+  return app.toTree();
+};
+```
+
 ## Developing
 
 ### Setup

--- a/blueprints/ember-calendar/index.js
+++ b/blueprints/ember-calendar/index.js
@@ -18,7 +18,8 @@ module.exports = {
       return this.addBowerPackagesToProject([
         { name: 'interact', target: '1.2.5' },
         { name: 'jquery-simulate', target: '1.0.1' },
-        { name: 'lodash', target: '3.10.0' }
+        { name: 'lodash', target: '3.10.0' },
+        { name: 'fontawesome', target: '~4.5.0'}
       ]);
     });
   }

--- a/index.js
+++ b/index.js
@@ -8,31 +8,44 @@ module.exports = {
 
   included: function(app) {
     this._super.included(app);
+    
+    var options = app.options.emberCalendar || {};
+
+    if (!('includeFontAwesomeAssets' in options)) {
+      options.includeFontAwesomeAssets = true;
+    }
 
     app.import(path.join(app.bowerDirectory, 'lodash/lodash.js'));
     app.import(path.join(app.bowerDirectory, 'interact/interact.js'));
     app.import(path.join(app.bowerDirectory, 'moment/moment.js'));
     app.import(path.join(app.bowerDirectory, 'moment-timezone/builds/moment-timezone-with-data.js'));
 
-    app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.ttf'), {
-      destDir: 'fonts'
-    });
 
-    app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.woff'), {
-      destDir: 'fonts'
-    });
+    if (options.includeFontAwesomeAssets) {
 
-    app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.woff2'), {
-      destDir: 'fonts'
-    });
+      app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.ttf'), {
+        destDir: 'fonts'
+      });
 
-    app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.svg'), {
-      destDir: 'fonts'
-    });
+      app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.woff'), {
+        destDir: 'fonts'
+      });
 
-    app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.eot'), {
-      destDir: 'fonts'
-    });
+      app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.woff2'), {
+        destDir: 'fonts'
+      });
+
+      app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.svg'), {
+        destDir: 'fonts'
+      });
+
+      app.import(path.join(app.bowerDirectory, 'fontawesome/fonts/fontawesome-webfont.eot'), {
+        destDir: 'fonts'
+      });
+    }
+
+
+
 
     app.import('vendor/ember-calendar/lodash.js', {
       type: 'vendor',


### PR DESCRIPTION
A few font awesome build issues with version v0.3.0:

1. The fontawesome imports in index.js cause a build error if these fonts are already being imported in your project (for example if you use the very popular ember-cli-font-awesome addon).
2. Adding the addon to a new project and running the build will fail because the font awesome dependency is missing. 

This PR fixes #1 by allowing users to optionally prevent those assets from being exported (they are still exported by default). The fix for #2 is to add the required font-awesome dependency to the project's bower.json on install along with the other dependencies that are already being added.

Let me know if you see anything that should be changed.