### PR TITLE
For newly created occurrences, 'endsAt' should be a Date like 'startsAt' not a moment object

### DIFF
--- a/addon/models/calendar.js
+++ b/addon/models/calendar.js
@@ -51,7 +51,7 @@ export default Ember.Object.extend({
   createOccurrence: function(options) {
     var content = Ember.merge({
       endsAt: moment(options.startsAt)
-        .add(this.get('defaultOccurrenceDuration')),
+        .add(this.get('defaultOccurrenceDuration')).toDate(),
 
       title: this.get('defaultOccurrenceTitle')
     }, options);

--- a/tests/unit/components/as-calendar-test.js
+++ b/tests/unit/components/as-calendar-test.js
@@ -54,6 +54,14 @@ test('Add an occurrence', function(assert) {
   assert.equal(Ember.$('.as-calendar-occurrence').length, 1,
     'it adds the occurrence to the calendar'
   );
+
+  assert.ok(this.get('occurrences.firstObject').startsAt instanceof Date,
+    'startsAt is a Date'
+  );
+
+  assert.ok(this.get('occurrences.firstObject').endsAt instanceof Date,
+    'endsAt is a Date'
+  );
 });
 
 test('Remove an occurrence', function(assert) {


### PR DESCRIPTION
Newly created calendar items currently return an object with a Date for 'startsAt' but a moment object for 'endsAt'. So, users of the addon have to handle them differently.

This change ensures both are Date objects. Also modifies a a unit test to comfirm the types.