### PR TITLE
Fire an onNavigateWeek action that users can optionally choose to implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ example, you can customize the appearance of the occurrences by passing a block:
   timeZoneOptions=timeZoneOptions
   showTimeZoneSearch=false
   timeZone=timeZone
+  onNavigateWeek=(action "calendarNavigateWeek")
   onAddOccurrence=(action "calendarAddOccurrence") as |occurrence timetable calendar|}}
   {{#if occurrence.content.isEditable}}
     {{as-calendar/timetable/occurrence

--- a/addon/components/as-calendar.js
+++ b/addon/components/as-calendar.js
@@ -38,6 +38,12 @@ export default Ember.Component.extend(InboundActionsMixin, {
       });
 
       this.attrs['onAddOccurrence'](occurrence.get('content'));
+    },
+
+    onNavigateWeek: function(index) {
+      if (this.attrs['onNavigateWeek']) {
+        this.attrs['onNavigateWeek'](index);
+      }
     }
   }
 });

--- a/addon/components/as-calendar/header.js
+++ b/addon/components/as-calendar/header.js
@@ -11,6 +11,10 @@ export default Ember.Component.extend({
   actions: {
     navigateWeek: function(index) {
       this.get('model').navigateWeek(index);
+
+      if (this.attrs['onNavigateWeek']) {
+        this.attrs['onNavigateWeek'](index);
+      }
     },
 
     goToCurrentWeek: function() {

--- a/addon/test-helpers/all.js
+++ b/addon/test-helpers/all.js
@@ -67,12 +67,26 @@ var selectTimeZone = function(name) {
   });
 };
 
+var selectNextWeek = function() {
+  Ember.run(() => {
+    Ember.$('button.as-calendar-header__nav-group-action--next-week').click();
+  });
+};
+
+var selectPreviousWeek = function() {
+  Ember.run(() => {
+    Ember.$('button.as-calendar-header__nav-group-action--previous-week').click();
+  });
+};
+
 export {
   timeSlotHeight,
   dayWidth,
   selectTime,
   resizeOccurrence,
   dragOccurrence,
-  selectTimeZone
+  selectTimeZone,
+  selectNextWeek,
+  selectPreviousWeek
 };
 

--- a/app/templates/components/as-calendar.hbs
+++ b/app/templates/components/as-calendar.hbs
@@ -1,5 +1,8 @@
 {{#if showHeader}}
-  {{as-calendar/header title=title model=model}}
+  {{as-calendar/header 
+    title=title 
+    model=model 
+    onNavigateWeek=(action "onNavigateWeek")}}
 {{/if}}
 
 {{#as-calendar/timetable

--- a/tests/unit/components/as-calendar-test.js
+++ b/tests/unit/components/as-calendar-test.js
@@ -9,7 +9,9 @@ import {
   selectTime,
   resizeOccurrence,
   dragOccurrence,
-  selectTimeZone
+  selectTimeZone,
+  selectNextWeek,
+  selectPreviousWeek
 } from 'ember-calendar/test-helpers/all';
 
 moduleForComponent('as-calendar', 'AsCalendarComponent', {
@@ -196,4 +198,29 @@ test('Change time zone', function(assert) {
 
   assert.equal(Ember.$('.as-calendar-occurrence').position().top, timeSlotHeight() * 2,
     'it shows the occurrence in the Rome time zone');
+});
+
+test('Change week', function(assert) {
+
+  var weekIndex = 0;
+
+  this.on('navigateWeek', (index) => {
+    weekIndex += index;
+  });
+
+  this.render(hbs`
+    {{as-calendar
+      title="Ember Calendar"
+      occurrences=occurrences
+      onRemoveOccurrence=(action "calendarRemoveOccurrence")
+      onNavigateWeek=(action "navigateWeek")}}
+  `);
+
+  selectNextWeek();
+
+  assert.equal(weekIndex, 1, 'it navigates to the next week');
+
+  selectPreviousWeek();
+
+  assert.equal(weekIndex, 0, 'it navigates back to the current week');
 });


### PR DESCRIPTION
For my use of the calendar addon, I needed to be notified when a user navigates to a different week. I realize this can be done by hacking in event listeners on the navigation buttons, or by implementing custom as-calendar and and header components, but this is cleaner and easier for users of the addon. 

Submitting this back for your consideration. This change will fire an 'onNavigateWeek' action that users can _optionally_ choose to implement (for backward compatibility it only fires if the action is configured). So this modification will not require that existing users of the addon make any changes when they upgrade.

Please let me know if you see a better way of implementing this. Alternatively, it could just fire an event. But I didn't see any existing use of events outside of tests. 