### PR TITLE
Make timetable title styleable

### DIFF
--- a/app/templates/components/as-calendar/timetable.hbs
+++ b/app/templates/components/as-calendar/timetable.hbs
@@ -12,7 +12,11 @@
     <ul>
       {{#each days as |day|}}
         <li class="as-calendar-timetable__column-item {{if day.isToday "as-calendar-timetable__column-item--highlighted"}}">
-          {{moment-format day.value "ddd D MMM"}}
+          {{moment-format day.value "ddd"}}
+
+          <span class="as-calendar-timetable__item-subtitle">
+            {{moment-format day.value "D MMM"}}
+          </span>
         </li>
       {{/each}}
     </ul>


### PR DESCRIPTION
Putting the day/month into a separate span allows doing this kind of styling:

![screen_shot_2016-04-01_at_17_54_21](https://cloud.githubusercontent.com/assets/1321353/14214289/30a97362-f834-11e5-9114-7cc0f6b5a9a3.png)

