### PR TITLE
Update _time-zone-select.scss

### DIFF
--- a/app/styles/addons/ember-calendar/components/as-calendar/_time-zone-select.scss
+++ b/app/styles/addons/ember-calendar/components/as-calendar/_time-zone-select.scss
@@ -49,7 +49,7 @@
 
     .search,
     .results {
-      @extend %dropdown-item;
+      @extend %dropdown-item !optional;
     }
 
     .search {
@@ -101,7 +101,7 @@
         padding: 0;
 
         > li {
-          @extend %dropdown-item;
+          @extend %dropdown-item !optional;
 
           cursor: pointer;
           padding: dropdown-settings(search, padding-inner) $column-gutter / 2;


### PR DESCRIPTION
Temp Fix: To avoid #48 `The Broccoli Plugin: [SassCompiler] failed with: Error: ".as-calendar-time-zone-select .rl-dropdown .search" failed to @extend "%dropdown-item". The selector "%dropdown-item" was not found.`

Need to check for the best solution. Any help in making that would be awesome.. I would love to work on this plugin.