### PR TITLE
Change first day of the week

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ In addition, you can customize the timezone handling using these options:
 * `defaultTimeZoneQuery`
 * `showTimeZoneSearch`
 
+You can specify the initial week displayed by the calendar using the `startingDate` option. In addition, if you want the week to begin from that day, pass `startFromDate=true`.
+
 ## Styles
 
 We do not add any vendor CSS to your app by default, but you can include it if you want by doing:

--- a/addon/components/as-calendar.js
+++ b/addon/components/as-calendar.js
@@ -17,6 +17,7 @@ export default Ember.Component.extend({
   showHeader: true,
   showTimeZoneSearch: true,
   startingDate: null,
+  startFromDate: null,
   timeSlotDuration: '00:30',
   timeSlotHeight: 20,
   timeZone: jstz.determine().name(),

--- a/addon/models/calendar.js
+++ b/addon/models/calendar.js
@@ -9,6 +9,7 @@ export default Ember.Object.extend({
   dayStartingTime: null,
   occurrences: null,
   startingDate: null,
+  startFromDate: false,
   timeSlotDuration: null,
   timeZone: null,
   occurrencePreview: null,
@@ -34,8 +35,12 @@ export default Ember.Object.extend({
     return Day.buildWeek({ calendar: this });
   }),
 
-  week: Ember.computed('startingTime', 'timeZone', function() {
-    return moment(this.get('startingTime')).tz(this.get('timeZone')).startOf('isoWeek');
+  week: Ember.computed('startFromDate', 'startingTime', 'timeZone', function() {
+    if (this.get('startFromDate')) {
+      return moment(this.get('startingTime')).tz(this.get('timeZone')).startOf('day');
+    } else {
+      return moment(this.get('startingTime')).tz(this.get('timeZone')).startOf('isoWeek');
+    }
   }),
 
   _currentWeek: Ember.computed('timeZone', function() {
@@ -52,7 +57,6 @@ export default Ember.Object.extend({
     var content = Ember.merge({
       endsAt: moment(options.startsAt)
         .add(this.get('defaultOccurrenceDuration')).toDate(),
-
       title: this.get('defaultOccurrenceTitle')
     }, options);
 

--- a/addon/models/component-calendar.js
+++ b/addon/models/component-calendar.js
@@ -7,6 +7,7 @@ import OccurrenceProxy from './occurrence-proxy';
 export default Calendar.extend({
   component: null,
   timeZone: Ember.computed.oneWay('component.timeZone'),
+  startFromDate: Ember.computed.readOnly('component.startFromDate'),
   startingTime: computedMoment('component.startingDate'),
   dayStartingTime: computedDuration('component.dayStartingTime'),
   dayEndingTime: computedDuration('component.dayEndingTime'),

--- a/addon/models/day.js
+++ b/addon/models/day.js
@@ -17,8 +17,8 @@ var Day = Ember.Object.extend({
     return this.get('calendar.occurrences').filter((occurrence) => {
       var startingTime = occurrence.get('startingTime');
 
-      return startingTime >= this.get('startingTime') &&
-             startingTime <= this.get('endingTime');
+      return startingTime.isSameOrAfter(this.get('startingTime')) &&
+             startingTime.isSameOrBefore(this.get('endingTime'));
     });
   }),
 

--- a/addon/models/occurrence-proxy.js
+++ b/addon/models/occurrence-proxy.js
@@ -16,10 +16,19 @@ var OccurrenceProxy = Ember.Object.extend(Ember.Copyable, {
     );
   }),
 
-  day: Ember.computed('startingTime', 'calendar', function() {
+  day: Ember.computed('startingTime', 'calendar', 'calendar.{startingTime,startFromDate}', function() {
+    let currentDay = this.get('startingTime');
+    let firstDay;
+
+    if (this.get('calendar.startFromDate')) {
+      firstDay = this.get('calendar.startingTime');
+    } else {
+      firstDay = this.get('calendar.startingTime').startOf('isoWeek');
+    }
+
     return Day.create({
       calendar: this.get('calendar'),
-      offset: this.get('startingTime').isoWeekday() - 1
+      offset: currentDay.dayOfYear() - firstDay.dayOfYear()
     });
   }),
 

--- a/tests/unit/components/as-calendar-test.js
+++ b/tests/unit/components/as-calendar-test.js
@@ -189,3 +189,38 @@ test('Change week', function(assert) {
 
   assert.equal(weekIndex, 0, 'it navigates back to the current week');
 });
+
+test('Displays week of specified day', function(assert) {
+  this.render(hbs`
+    {{as-calendar
+      title="Ember Calendar"
+      occurrences=occurrences
+      startingDate="2017-06-08"}}
+  `);
+
+  assert.equal(this.$('.as-calendar-timetable__column-item:first-child').text().trim(), 'Mon 5 Jun');
+});
+
+test('Week starts from specified day', function(assert) {
+  this.render(hbs`
+    {{as-calendar
+      title="Ember Calendar"
+      occurrences=occurrences
+      startingDate="2017-06-08"
+      startFromDate=true}}
+  `);
+
+  assert.equal(this.$('.as-calendar-timetable__column-item:first-child').text().trim(), 'Thu 8 Jun');
+});
+
+test('Week starts from today', function(assert) {
+  this.render(hbs`
+    {{as-calendar
+      title="Ember Calendar"
+      occurrences=occurrences
+      startFromDate=true}}
+  `);
+
+  const today = moment().format('ddd D MMM');
+  assert.equal(this.$('.as-calendar-timetable__column-item:first-child').text().trim(), today);
+});


### PR DESCRIPTION
Introduce `startFromDate` option 🎉 

E.g:
- `startFromDate=true` will make the first day of the week the current day.
- `startFromDate=true startingDate='2017-06-24'` will make the first day of the week Saturday 24th of June.