### PR TITLE
Identify preview objects in update function

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ export default Ember.Controller.extend({
       }));
     },
 
-    calendarUpdateOccurrence: function(occurrence, properties) {
+    calendarUpdateOccurrence: function(occurrence, properties, isPreview) {
       occurrence.setProperties(properties);
+
+      if (!isPreview) {
+        occurrence.save();
+      }
     },
 
     calendarRemoveOccurrence: function(occurrence) {

--- a/addon/components/as-calendar/timetable/occurrence.js
+++ b/addon/components/as-calendar/timetable/occurrence.js
@@ -86,7 +86,7 @@ export default OccurrenceComponent.extend({
   _resizeEnd: function() {
     this.attrs.onUpdate(this.get('content'), {
       endsAt: this.get('_preview.content.endsAt')
-    });
+    }, false);
 
     this.set('isInteracting', false);
     this.set('_calendar.occurrencePreview', null);
@@ -153,7 +153,7 @@ export default OccurrenceComponent.extend({
     this.attrs.onUpdate(this.get('content'), {
       startsAt: this.get('_preview.content.startsAt'),
       endsAt: this.get('_preview.content.endsAt')
-    });
+    }, false);
 
     this.set('isInteracting', false);
     this.set('_calendar.occurrencePreview', null);
@@ -168,7 +168,7 @@ export default OccurrenceComponent.extend({
 
   _validateAndSavePreview: function(changes) {
     if (this._validatePreviewChanges(changes)) {
-      this.attrs.onUpdate(this.get('_preview.content'), changes);
+      this.attrs.onUpdate(this.get('_preview.content'), changes, true);
     }
   },
 

--- a/tests/unit/components/as-calendar-test.js
+++ b/tests/unit/components/as-calendar-test.js
@@ -224,3 +224,33 @@ test('Week starts from today', function(assert) {
   const today = moment().format('ddd D MMM');
   assert.equal(this.$('.as-calendar-timetable__column-item:first-child').text().trim(), today);
 });
+
+test('Update function differentiates preview and original object', function(assert) {
+  assert.expect(4);
+
+  this.on('calendarUpdateOccurrence', (occurrence, properties, isPreview) => {
+    occurrence.setProperties(properties);
+
+    if (isPreview) {
+      assert.notDeepEqual(occurrence, this.get('occurrences.firstObject'), 'Passed occurrence not same as original');
+    } else {
+      assert.deepEqual(occurrence, this.get('occurrences.firstObject'), 'Passed occurrence is same as original');
+    }
+  });
+
+  this.render(hbs`
+    {{as-calendar
+      title="Ember Calendar"
+      occurrences=occurrences
+      dayStartingTime="9:00"
+      dayEndingTime="18:00"
+      timeSlotDuration="00:30"
+      onAddOccurrence=(action "calendarAddOccurrence")
+      onUpdateOccurrence=(action "calendarUpdateOccurrence")
+      onRemoveOccurrence=(action "calendarRemoveOccurrence")}}
+  `);
+
+  selectTime({ day: 0, timeSlot: 0 });
+
+  dragOccurrence(this.$('.as-calendar-occurrence'), { days: 2, timeSlots: 4 });
+});


### PR DESCRIPTION
- Adds `isPreview` to function signature for the update function.

As you may guess, `isPreview` is true when the object passed is a preview, otherwise it is false. Closes https://github.com/alphasights/ember-calendar/issues/127 🎉 