### PR TITLE
computed moment tz

### DIFF
--- a/addon/macros/computed-moment.js
+++ b/addon/macros/computed-moment.js
@@ -3,13 +3,14 @@ import Ember from 'ember';
 
 const { computed } = Ember;
 
-export default function(dependentKey) {
-  return computed(dependentKey, {
+export default function(dependentKey, timeZoneKey) {
+  return computed(dependentKey, timeZoneKey, {
     get() {
       var dependentValue = this.get(dependentKey);
+      let timezone = this.get(timeZoneKey);
 
       if (dependentValue != null) {
-        return moment(dependentValue);
+        return moment(dependentValue).tz(timezone);
       } else {
         return null;
       }

--- a/addon/models/component-calendar.js
+++ b/addon/models/component-calendar.js
@@ -8,7 +8,7 @@ export default Calendar.extend({
   component: null,
   timeZone: Ember.computed.oneWay('component.timeZone'),
   startFromDate: Ember.computed.readOnly('component.startFromDate'),
-  startingTime: computedMoment('component.startingDate'),
+  startingTime: computedMoment('component.startingDate', 'timeZone'),
   dayStartingTime: computedDuration('component.dayStartingTime'),
   dayEndingTime: computedDuration('component.dayEndingTime'),
   timeSlotDuration: computedDuration('component.timeSlotDuration'),

--- a/addon/models/occurrence-proxy.js
+++ b/addon/models/occurrence-proxy.js
@@ -6,8 +6,8 @@ import Day from './day';
 var OccurrenceProxy = Ember.Object.extend(Ember.Copyable, {
   calendar: null,
   content: null,
-  endingTime: computedMoment('content.endsAt'),
-  startingTime: computedMoment('content.startsAt'),
+  endingTime: computedMoment('content.endsAt', 'calendar.timeZone'),
+  startingTime: computedMoment('content.startsAt', 'calendar.timeZone'),
   title: Ember.computed.oneWay('content.title'),
 
   duration: Ember.computed('startingTime', 'endingTime', function() {

--- a/tests/unit/macros/computed-moment-test.js
+++ b/tests/unit/macros/computed-moment-test.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import { test, module } from 'ember-qunit';
+import computedMoment from 'ember-calendar/macros/computed-moment';
+import moment from 'moment';
+
+module('macros | computed moment', 'computedMoment');
+
+test('it returns a moment when getting', function(assert) {
+  assert.expect(1);
+
+  let date = new Date();
+
+  let Component = Ember.Object.extend({
+    _startingTime: date,
+    timeZone: 'Australia/Sydney',
+
+    startingTime: computedMoment('_startingTime', 'timeZone')
+  });
+
+  let subject = Component.create();
+  let startingTime = subject.get('startingTime');
+  let expected = moment(date).tz('Australia/Sydney');
+
+  assert.equal(startingTime.toString(), expected.toString());
+});


### PR DESCRIPTION
It seems that we need to apply the timezone to the starting time value here. The reason being:

- When you change the timezone and the date falls on the edge of midnight it doesn't recalculate the new starting time with the new timezone. This matters if the new starting time falls under a different day because the day determines which time slots belong to it when rendering.