### PR TITLE
Ensure we use correct offset for timezone test

### DIFF
--- a/tests/unit/components/as-calendar-test.js
+++ b/tests/unit/components/as-calendar-test.js
@@ -150,12 +150,16 @@ test('Change time zone', function(assert) {
   selectTime({ day: 0, timeSlot: 0 });
 
   assert.equal(Ember.$('.as-calendar-occurrence').position().top, 0,
-    'it shows the occurrence in the UTC time zone');
+    'it shows the occurrence in the London time zone');
 
   selectTimeZone('Rome');
 
   let tzOffset;
-  if (moment().tz('Europe/Rome').isDST()) {
+
+  const romeDst = moment().tz('Europe/Rome').isDST();
+  const londonDst = moment().tz('Europe/London').isDST();
+
+  if (romeDst === londonDst) {
     tzOffset = 1;
   } else {
     tzOffset = 2;


### PR DESCRIPTION
Seems like we were having issues because the test thought the offset should be 2 (as opposed to 1, which is the usual offset)