### PR TITLE
run ember-modules-codemod

### DIFF
--- a/MODULE_REPORT.md
+++ b/MODULE_REPORT.md
@@ -1,0 +1,28 @@
+## Module Report
+### Unknown Global
+
+**Global**: `Ember.Copyable`
+
+**Location**: `addon/models/occurrence-proxy.js` at line 6
+
+```js
+import Day from './day';
+
+var OccurrenceProxy = Ember.Object.extend(Ember.Copyable, {
+  calendar: null,
+  content: null,
+```
+
+### Unknown Global
+
+**Global**: `Ember.MODEL_FACTORY_INJECTIONS`
+
+**Location**: `tests/dummy/app/app.js` at line 8
+
+```js
+let App;
+
+Ember.MODEL_FACTORY_INJECTIONS = true;
+
+App = Ember.Application.extend({
+```

--- a/addon/components/as-calendar.js
+++ b/addon/components/as-calendar.js
@@ -1,8 +1,9 @@
+import { on } from '@ember/object/evented';
+import Component from '@ember/component';
 import jstz from 'jstz';
-import Ember from 'ember';
 import ComponentCalendar from 'ember-calendar/models/component-calendar';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: [':as-calendar'],
   tagName: 'section',
 
@@ -23,7 +24,7 @@ export default Ember.Component.extend({
   timeZone: jstz.determine().name(),
   title: null,
 
-  _initializeModel: Ember.on('init', function() {
+  _initializeModel: on('init', function() {
     this.set('model', ComponentCalendar.create({ component: this }));
   }),
 

--- a/addon/components/as-calendar/header.js
+++ b/addon/components/as-calendar/header.js
@@ -1,10 +1,11 @@
-import Ember from 'ember';
+import { oneWay } from '@ember/object/computed';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: [':as-calendar-header'],
   tagName: 'header',
 
-  isInCurrentWeek: Ember.computed.oneWay('model.isInCurrentWeek'),
+  isInCurrentWeek: oneWay('model.isInCurrentWeek'),
   model: null,
   title: '',
 

--- a/addon/components/as-calendar/occurrence.js
+++ b/addon/components/as-calendar/occurrence.js
@@ -1,10 +1,12 @@
-import Ember from 'ember';
+import { on } from '@ember/object/evented';
+import { htmlSafe } from '@ember/template';
+import { oneWay } from '@ember/object/computed';
+import Component from '@ember/component';
+import { get, computed } from '@ember/object';
 import computedDuration from 'ember-calendar/macros/computed-duration';
 import moment from 'moment';
 
-const { get } = Ember;
-
-export default Ember.Component.extend({
+export default Component.extend({
   attributeBindings: ['_style:style'],
   classNameBindings: [':as-calendar-occurrence'],
   tagName: 'article',
@@ -12,37 +14,37 @@ export default Ember.Component.extend({
   model: null,
   timeSlotDuration: null,
   timeSlotHeight: null,
-  title: Ember.computed.oneWay('model.title'),
-  content: Ember.computed.oneWay('model.content'),
-  day: Ember.computed.oneWay('model.day'),
+  title: oneWay('model.title'),
+  content: oneWay('model.content'),
+  day: oneWay('model.day'),
   computedTimeSlotDuration: computedDuration('timeSlotDuration'),
 
-  titleStyle: Ember.computed('timeSlotHeight', function() {
-    return Ember.String.htmlSafe(`line-height: ${this.get('timeSlotHeight')}px;`);
+  titleStyle: computed('timeSlotHeight', function() {
+    return htmlSafe(`line-height: ${this.get('timeSlotHeight')}px;`);
   }),
 
-  _duration: Ember.computed.oneWay('model.duration'),
-  _startingTime: Ember.computed('model.startingTime', function() {
+  _duration: oneWay('model.duration'),
+  _startingTime: computed('model.startingTime', function() {
     let time = get(this, 'model.startingTime');
     let zone = get(this, 'model.calendar.timeZone');
 
     return moment(time).tz(zone);
   }),
 
-  _dayStartingTime: Ember.computed.oneWay('day.startingTime'),
+  _dayStartingTime: oneWay('day.startingTime'),
 
-  _occupiedTimeSlots: Ember.computed(
+  _occupiedTimeSlots: computed(
     '_duration',
     'computedTimeSlotDuration', function() {
       return this.get('_duration').as('ms') /
              this.get('computedTimeSlotDuration').as('ms');
   }),
 
-  _height: Ember.computed('_occupiedTimeSlots', function() {
+  _height: computed('_occupiedTimeSlots', function() {
     return this.get('timeSlotHeight') * this.get('_occupiedTimeSlots');
   }),
 
-  _top: Ember.computed(
+  _top: computed(
     '_startingTime',
     '_dayStartingTime',
     'computedTimeSlotDuration',
@@ -52,12 +54,12 @@ export default Ember.Component.extend({
             this.get('timeSlotHeight');
   }),
 
-  _style: Ember.computed('_height', '_top', function() {
-    return Ember.String.htmlSafe(`top: ${this.get('_top')}px;
+  _style: computed('_height', '_top', function() {
+    return htmlSafe(`top: ${this.get('_top')}px;
             height: ${this.get('_height')}px;`);
   }),
 
-  _stopPropagation: Ember.on('click', function(event) {
+  _stopPropagation: on('click', function(event) {
     event.stopPropagation();
   }),
 });

--- a/addon/components/as-calendar/time-zone-option.js
+++ b/addon/components/as-calendar/time-zone-option.js
@@ -1,19 +1,22 @@
-import Ember from 'ember';
+import { on } from '@ember/object/evented';
+import { computed } from '@ember/object';
+import { oneWay } from '@ember/object/computed';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: [':as-calendar-time-zone-option', 'isSelected:selected'],
 
-  description: Ember.computed.oneWay('option.description'),
+  description: oneWay('option.description'),
   option: null,
   selectedOption: null,
 
-  isSelected: Ember.computed(
+  isSelected: computed(
     'selectedOption.value',
     'option.value', function() {
       return this.get('selectedOption.value') === this.get('option.value');
   }),
 
-  _selectOption: Ember.on('click', function() {
+  _selectOption: on('click', function() {
     this.attrs.onSelect(this.get('option.value'));
   })
 });

--- a/addon/components/as-calendar/time-zone-select.js
+++ b/addon/components/as-calendar/time-zone-select.js
@@ -1,8 +1,12 @@
+import { debounce } from '@ember/runloop';
+import { isEmpty, isPresent } from '@ember/utils';
+import { computed } from '@ember/object';
+import { oneWay } from '@ember/object/computed';
+import Component from '@ember/component';
 import moment from 'moment';
-import Ember from 'ember';
 import TimeZoneOption from 'ember-calendar/models/time-zone-option';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: [':as-calendar-time-zone-select', 'showResults:open'],
   tagName: 'section',
 
@@ -14,11 +18,11 @@ export default Ember.Component.extend({
   options: null,
   showSearch: true,
 
-  selectedOptionAbbreviation: Ember.computed.oneWay(
+  selectedOptionAbbreviation: oneWay(
     'selectedOption.abbreviation'
   ),
 
-  arrangedOptions: Ember.computed(
+  arrangedOptions: computed(
     '_options.@each.{description,value}',
     'selectedOption.value',
     'showSearch',
@@ -35,7 +39,7 @@ export default Ember.Component.extend({
     }
   }),
 
-  selectedOption: Ember.computed('value', function() {
+  selectedOption: computed('value', function() {
     let value = this.get('value');
 
     if (value) {
@@ -43,18 +47,18 @@ export default Ember.Component.extend({
     }
   }),
 
-  _query: Ember.computed('query', 'defaultQuery', function() {
+  _query: computed('query', 'defaultQuery', function() {
     let query = this.get('query');
 
-    if (Ember.isEmpty(query)) {
+    if (isEmpty(query)) {
        return this.get('defaultQuery');
     } else {
       return query;
     }
   }),
 
-  _options: Ember.computed('options', function() {
-    if (Ember.isPresent(this.get('options'))) {
+  _options: computed('options', function() {
+    if (isPresent(this.get('options'))) {
       return this.get('options');
     } else {
       return moment.tz.names().map(function(timeZoneName) {
@@ -69,7 +73,7 @@ export default Ember.Component.extend({
 
   actions: {
     inputQueryChanged: function(value) {
-      Ember.run.debounce(this, this._setQuery, value, 200);
+      debounce(this, this._setQuery, value, 200);
     }
   }
 });

--- a/addon/components/as-calendar/timetable.js
+++ b/addon/components/as-calendar/timetable.js
@@ -1,31 +1,34 @@
-import Ember from 'ember';
+import { htmlSafe } from '@ember/template';
+import { computed } from '@ember/object';
+import { oneWay } from '@ember/object/computed';
+import Component from '@ember/component';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: [':as-calendar-timetable'],
   tagName: 'section',
 
-  days: Ember.computed.oneWay('model.days'),
+  days: oneWay('model.days'),
   model: null,
   timeSlotHeight: null,
-  timeSlots: Ember.computed.oneWay('model.timeSlots'),
+  timeSlots: oneWay('model.timeSlots'),
   contentComponent: null,
-  dayWidth: Ember.computed.oneWay('contentComponent.dayWidth'),
-  referenceElement: Ember.computed.oneWay('contentComponent.element'),
+  dayWidth: oneWay('contentComponent.dayWidth'),
+  referenceElement: oneWay('contentComponent.element'),
 
-  labeledTimeSlots: Ember.computed('timeSlots.[]', function() {
+  labeledTimeSlots: computed('timeSlots.[]', function() {
     return this.get('timeSlots').filter(function(_, index) {
       return (index % 2) === 0;
     });
   }),
 
-  timeSlotLabelListStyle: Ember.computed('timeSlotHeight', function() {
+  timeSlotLabelListStyle: computed('timeSlotHeight', function() {
     var timeSlotHeight = this.get('timeSlotHeight');
 
-    return Ember.String.htmlSafe(`margin-top: -${timeSlotHeight}px;
+    return htmlSafe(`margin-top: -${timeSlotHeight}px;
              line-height: ${timeSlotHeight * 2}px;`);
   }),
 
-  timeSlotLabelStyle: Ember.computed('timeSlotHeight', function() {
-    return Ember.String.htmlSafe(`height: ${2 * this.get('timeSlotHeight')}px;`);
+  timeSlotLabelStyle: computed('timeSlotHeight', function() {
+    return htmlSafe(`height: ${2 * this.get('timeSlotHeight')}px;`);
   })
 });

--- a/addon/components/as-calendar/timetable/content.js
+++ b/addon/components/as-calendar/timetable/content.js
@@ -1,21 +1,25 @@
-import Ember from 'ember';
+import { on } from '@ember/object/evented';
+import { htmlSafe } from '@ember/template';
+import { computed } from '@ember/object';
+import { oneWay } from '@ember/object/computed';
+import Component from '@ember/component';
 import moment from 'moment';
 
-export default Ember.Component.extend({
+export default Component.extend({
   classNameBindings: [':as-calendar-timetable-content'],
   attributeBindings: ['_style:style'],
 
-  days: Ember.computed.oneWay('model.days'),
+  days: oneWay('model.days'),
   model: null,
-  timeSlotDuration: Ember.computed.oneWay('model.timeSlotDuration'),
-  timeSlots: Ember.computed.oneWay('model.timeSlots'),
+  timeSlotDuration: oneWay('model.timeSlotDuration'),
+  timeSlots: oneWay('model.timeSlots'),
   timetable: null,
 
-  timeSlotStyle: Ember.computed('timeSlotHeight', function() {
-    return Ember.String.htmlSafe(`height: ${this.get('timeSlotHeight')}px`);
+  timeSlotStyle: computed('timeSlotHeight', function() {
+    return htmlSafe(`height: ${this.get('timeSlotHeight')}px`);
   }),
 
-  dayWidth: Ember.computed(function() {
+  dayWidth: computed(function() {
     if (this.get('_wasInserted')) {
       return this.$().width() / this.get('days.length');
     } else {
@@ -25,22 +29,22 @@ export default Ember.Component.extend({
 
   _wasInserted: false,
 
-  _style: Ember.computed(
+  _style: computed(
   'timeSlotHeight',
   'timeSlots.length', function() {
-    return Ember.String.htmlSafe(`height: ${this.get('timeSlots.length') *
+    return htmlSafe(`height: ${this.get('timeSlots.length') *
                        this.get('timeSlotHeight')}px;`);
   }),
 
-  _setWasInserted: Ember.on('didInsertElement', function() {
+  _setWasInserted: on('didInsertElement', function() {
     this.set('_wasInserted', true);
   }),
 
-  _registerWithParent: Ember.on('init', function() {
+  _registerWithParent: on('init', function() {
     this.set('timetable.contentComponent', this);
   }),
 
-  _selectTime: Ember.on('click', function(event) {
+  _selectTime: on('click', function(event) {
     var offset = this.$().offset();
     var offsetX = event.pageX - Math.floor(offset.left);
     var offsetY = event.pageY - Math.floor(offset.top);

--- a/addon/components/as-calendar/timetable/occurrence.js
+++ b/addon/components/as-calendar/timetable/occurrence.js
@@ -1,4 +1,7 @@
-import Ember from 'ember';
+import $ from 'jquery';
+import { run } from '@ember/runloop';
+import { on } from '@ember/object/evented';
+import { oneWay } from '@ember/object/computed';
 import moment from 'moment';
 import interact from 'interact';
 import OccurrenceComponent from '../occurrence';
@@ -11,19 +14,19 @@ export default OccurrenceComponent.extend({
   isDraggable: true,
   isResizable: true,
   isRemovable: true,
-  dayWidth: Ember.computed.oneWay('timetable.dayWidth'),
-  referenceElement: Ember.computed.oneWay('timetable.referenceElement'),
+  dayWidth: oneWay('timetable.dayWidth'),
+  referenceElement: oneWay('timetable.referenceElement'),
 
-  _calendar: Ember.computed.oneWay('model.calendar'),
-  _dayEndingTime: Ember.computed.oneWay('day.endingTime'),
+  _calendar: oneWay('model.calendar'),
+  _dayEndingTime: oneWay('day.endingTime'),
   _dragBottomDistance: null,
   _dragTopDistance: null,
   _dragVerticalOffset: null,
-  _preview: Ember.computed.oneWay('_calendar.occurrencePreview'),
+  _preview: oneWay('_calendar.occurrencePreview'),
 
-  _setupInteractable: Ember.on('didInsertElement', function() {
+  _setupInteractable: on('didInsertElement', function() {
     var interactable = interact(this.$()[0]).on('mouseup', (event) => {
-      Ember.run(this, this._mouseUp, event);
+      run(this, this._mouseUp, event);
     });
 
     if (this.get('isResizable')) {
@@ -31,15 +34,15 @@ export default OccurrenceComponent.extend({
         edges: { bottom: '.as-calendar-occurrence__resize-handle' },
 
         onstart: (event) => {
-          Ember.run(this, this._resizeStart, event);
+          run(this, this._resizeStart, event);
         },
 
         onmove: (event) => {
-          Ember.run(this, this._resizeMove, event);
+          run(this, this._resizeMove, event);
         },
 
         onend: (event) => {
-          Ember.run(this, this._resizeEnd, event);
+          run(this, this._resizeEnd, event);
         },
       });
     }
@@ -47,21 +50,21 @@ export default OccurrenceComponent.extend({
     if (this.get('isDraggable')) {
       interactable.draggable({
         onstart: (event) => {
-          Ember.run(this, this._dragStart, event);
+          run(this, this._dragStart, event);
         },
 
         onmove: (event) => {
-          Ember.run(this, this._dragMove, event);
+          run(this, this._dragMove, event);
         },
 
         onend: (event) => {
-          Ember.run(this, this._dragEnd, event);
+          run(this, this._dragEnd, event);
         },
       });
     }
   }),
 
-  _teardownInteractable: Ember.on('willDestroyElement', function() {
+  _teardownInteractable: on('willDestroyElement', function() {
     interact(this.$()[0]).off();
   }),
 
@@ -94,7 +97,7 @@ export default OccurrenceComponent.extend({
 
   _dragStart: function() {
     var $this = this.$();
-    var $referenceElement = Ember.$(this.get('referenceElement'));
+    var $referenceElement = $(this.get('referenceElement'));
 
     this.set('isInteracting', true);
     this.set('_calendar.occurrencePreview', this.get('model').copy());
@@ -134,7 +137,7 @@ export default OccurrenceComponent.extend({
   },
 
   _dragDayOffset: function(event) {
-    var $referenceElement = Ember.$(this.get('referenceElement'));
+    var $referenceElement = $(this.get('referenceElement'));
 
     var offsetX = this._clamp(
       event.pageX - $referenceElement.offset().left,
@@ -163,7 +166,7 @@ export default OccurrenceComponent.extend({
   },
 
   _mouseUp: function() {
-    Ember.$(document.documentElement).css('cursor', '');
+    $(document.documentElement).css('cursor', '');
   },
 
   _validateAndSavePreview: function(changes) {

--- a/addon/macros/computed-duration.js
+++ b/addon/macros/computed-duration.js
@@ -1,8 +1,8 @@
+import { computed } from '@ember/object';
 import moment from 'moment';
-import Ember from 'ember';
 
 export default function(dependentKey) {
-  return Ember.computed(dependentKey, function() {
+  return computed(dependentKey, function() {
     var dependentValue = this.get(dependentKey);
 
     if (dependentValue != null) {


### PR DESCRIPTION
Hi thanks for creating this library.
I've been working on a lot of changes to get it working well in my Ember 3 app, and this is one of them.
This updates the addon to use the new module syntax, e.g. instead of using the global `Ember` you can write:

`import Component from '@ember/component';`

I used the [ember-modules-codemod](https://github.com/ember-cli/ember-modules-codemod) to make all the changes.

I'm sure there are some details that might need adjustments or tests that might need fixing, so let me know if you notice anything.